### PR TITLE
fix: use correct model dump method in tutorial

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -116,10 +116,10 @@ Route::get('/', function () {
 
   return (
     // Get local ID token claims
-    $client->getIdTokenClaims()->modelDumpJson(excludeUnset: true)
+    json_decode($client->getIdTokenClaims())
     . "<br>"
     // Fetch user info from Logto userinfo endpoint
-    $client->fetchUserInfo()->modelDumpJson(excludeUnset: true)
+    json_decode($client->fetchUserInfo())
     . "<br><a href='/sign-out'>Sign out</a>"
   );
 });


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
should be `json_decode` instead the python method

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] This PR is not applicable for the checklist
