### PR TITLE
refactor: add metadata cache

### DIFF
--- a/samples/index.php
+++ b/samples/index.php
@@ -26,7 +26,7 @@
     )
   );
 
-  switch ($_SERVER['PATH_INFO']) {
+  switch (parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH)) {
     case '/':
     case null:
       if (!$client->isAuthenticated()) {

--- a/src/LogtoClient.php
+++ b/src/LogtoClient.php
@@ -64,7 +64,7 @@ class LogtoClient
 
   function __construct(public LogtoConfig $config, public Storage $storage = new SessionStorage())
   {
-    $this->oidcCore = OidcCore::create($config->endpoint);
+    $this->oidcCore = OidcCore::create(rtrim($config->endpoint, "/"));
   }
 
   /**


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- cache OIDC metadata for 1hr for better performance
- trim the ending `/` in the endpoint for better compatibility

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- added unit test
- local sign-in/out
