### PR TITLE
chore(deps): upgrade firebase/php-jwt to ^7.0 to fix security advisory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "firebase/php-jwt": "^6.8",
+        "firebase/php-jwt": "^7.0",
         "guzzlehttp/guzzle": "^7.7",
         "phpfastcache/phpfastcache": "^9.1",
         "vlucas/phpdotenv": "^5.5"

--- a/composer.lock
+++ b/composer.lock
@@ -4,30 +4,30 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2c8b3a40b8de2bec92d2cc2f728eb855",
+    "content-hash": "17fabe394c8fc0438655ffcc70458331",
     "packages": [
         {
             "name": "firebase/php-jwt",
-            "version": "v6.8.1",
+            "version": "v7.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "5dbc8959427416b8ee09a100d7a8588c00fb2e26"
+                "reference": "5645b43af647b6947daac1d0f659dd1fbe8d3b65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/5dbc8959427416b8ee09a100d7a8588c00fb2e26",
-                "reference": "5dbc8959427416b8ee09a100d7a8588c00fb2e26",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/5645b43af647b6947daac1d0f659dd1fbe8d3b65",
+                "reference": "5645b43af647b6947daac1d0f659dd1fbe8d3b65",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4||^8.0"
+                "php": "^8.0"
             },
             "require-dev": {
-                "guzzlehttp/guzzle": "^6.5||^7.4",
+                "guzzlehttp/guzzle": "^7.4",
                 "phpspec/prophecy-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.5",
-                "psr/cache": "^1.0||^2.0",
+                "psr/cache": "^2.0||^3.0",
                 "psr/http-client": "^1.0",
                 "psr/http-factory": "^1.0"
             },
@@ -65,9 +65,9 @@
             ],
             "support": {
                 "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v6.8.1"
+                "source": "https://github.com/firebase/php-jwt/tree/v7.0.2"
             },
-            "time": "2023-07-14T18:33:00+00:00"
+            "time": "2025-12-16T22:17:28+00:00"
         },
         {
             "name": "graham-campbell/result-type",


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- Upgrade `firebase/php-jwt` from `^6.8` to `^7.0` in `composer.json`
- Refresh `composer.lock` to `firebase/php-jwt v7.0.2`
- Resolve [Dependabot alert #2](https://github.com/logto-io/php/security/dependabot/2) (`GHSA-2x45-7fc3-mxwq` / `CVE-2025-45769`)

## Security Context
Dependabot flagged `firebase/php-jwt` versions `< 7.0.0` as vulnerable (high severity).  
This PR upgrades the dependency to a patched version (`>= 7.0.0`).

## Notes
`firebase/php-jwt` v7 introduces stricter key-strength validation.  
For this SDK usage (OIDC/JWKS verification), no functional behavior changes are expected.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- `composer test` → 42 tests passed
- `composer audit --format=plain` → No security vulnerability advisories found

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
