### PR TITLE
Update LogtoClient.php

### DIFF
--- a/src/LogtoClient.php
+++ b/src/LogtoClient.php
@@ -93,7 +93,23 @@ class LogtoClient
    */
   function getIdTokenClaims(): IdTokenClaims
   {
-    return new IdTokenClaims(...json_decode(base64_decode(explode('.', $this->getIdToken())[1]), true));
+        $playload = explode('.', $this->getIdToken())[1] ?? null;
+        if (empty($playload)) throw new \Exception("Invalid Playload data");
+
+        // 解决编码标准不一致的问题： (RFC 4648 §5) 与标准 Base64 (RFC 4648 §4)
+
+        // 1. 替换字符 (- -> +, _ -> /)
+        $data = strtr($playload, '-_', '+/');
+
+        // 2. 补全填充 (=)
+        $mod = strlen($data) % 4;
+        if ($mod > 0) {
+            $data .= str_repeat('=', 4 - $mod);
+        }
+
+        $playloadDecode = base64_decode($data, true);
+
+        return new IdTokenClaims(...json_decode($playloadDecode, true));
   }
 
   /**


### PR DESCRIPTION
修复用户资料中姓名为中文名（例如“测试”两个字）时，响应的base64文本格式标准不一的问题
Fix the problem where the response base64 text format is inconsistent when the user's name in the profile is in Chinese.